### PR TITLE
Credo and Auth Page fixes (0.0.14+27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [0.0.14+27] - 2022-04-15
+### Added
+- Homepage reload on loan cancellation
+- Keyboard actions on authentication form (next and submit)
+- Account locked message
+
+### Fixed
+- Credo "/" issue on ios, removed "/" from the environment variable
+- Authentication attempts with one or more empty fields are taken care of by the provider

--- a/android/app/src/main/kotlin/com/leafglobalfintech/loanapp/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/leafglobalfintech/loanapp/MainActivity.kt
@@ -64,7 +64,7 @@ class MainActivity : FlutterActivity() {
         val context = applicationContext
         // create an instance of CredoAppService
         if (::credoAppService.isInitialized.not())
-            credoAppService = CredoAppService.Builder(context, url, authKey)
+            credoAppService = CredoAppService.Builder(context, "${url}/", authKey)
                     .addModule(CalendarModule())
                     .addModule(ContactModule())
                     .addModule(MediaModule())

--- a/lib/authentication/data/repository/auth_remote_repo.dart
+++ b/lib/authentication/data/repository/auth_remote_repo.dart
@@ -37,7 +37,10 @@ class AuthRemoteRepo extends AuthenticationRepository {
         await _localStorage.setString(Keys.userId, userMap['id']);
         return right(result);
       } else {
-        // TODO(Yabsra): locked acc
+        if (((response.data as Map<String, dynamic>)['message'] as String)
+            .contains('locked')) {
+          return left(AuthFailure(reason: Reason.accountLocked));
+        }
         return left(AuthFailure(reason: Reason.invalidCredentials));
       }
     } catch (e, stacktrace) {

--- a/lib/authentication/presentation/providers/auth/auth_provider.dart
+++ b/lib/authentication/presentation/providers/auth/auth_provider.dart
@@ -46,14 +46,18 @@ class AuthProvider extends ChangeNotifier {
     loading = true;
     setErrorMessage('');
     notifyListeners();
-    final authEither = await _authenticationRepository.login(
-      username: username,
-      password: password,
-    );
-    authEither.fold(
-      (failure) => setErrorMessage(_getMessage(failure.reason)),
-      (success) => loggedIn = true,
-    );
+    if (username.isNotEmpty && password.isNotEmpty) {
+      final authEither = await _authenticationRepository.login(
+        username: username,
+        password: password,
+      );
+      authEither.fold(
+        (failure) => setErrorMessage(_getMessage(failure.reason)),
+        (success) => loggedIn = true,
+      );
+    } else {
+      setErrorMessage(_getMessage(Reason.invalidCredentials));
+    }
     loading = false;
     notifyListeners();
   }

--- a/lib/authentication/presentation/widgets/auth_text_field.dart
+++ b/lib/authentication/presentation/widgets/auth_text_field.dart
@@ -5,21 +5,27 @@ class AuthTextField extends StatelessWidget {
   const AuthTextField({
     Key? key,
     required this.controller,
+    this.focusNode,
     required this.hintText,
     this.inputFormatters = const [],
-    required this.keyboardType,
+    this.keyboardType,
     this.obscured = false,
     this.onSuffixPressed,
+    this.onSubmit,
     required this.suffixIcon,
+    this.textInputAction,
   }) : super(key: key);
 
   final String hintText;
   final TextEditingController controller;
+  final FocusNode? focusNode;
   final List<TextInputFormatter> inputFormatters;
-  final TextInputType keyboardType;
+  final TextInputType? keyboardType;
   final bool obscured;
+  final VoidCallback? onSubmit;
   final VoidCallback? onSuffixPressed;
   final IconData suffixIcon;
+  final TextInputAction? textInputAction;
 
   @override
   Widget build(BuildContext context) {
@@ -44,9 +50,12 @@ class AuthTextField extends StatelessWidget {
           },
         ),
       ),
+      focusNode: focusNode,
       keyboardType: keyboardType,
       inputFormatters: inputFormatters,
       obscureText: obscured,
+      onFieldSubmitted: (_) => onSubmit?.call(),
+      textInputAction: textInputAction,
     );
   }
 }

--- a/lib/authentication/presentation/widgets/submit_button.dart
+++ b/lib/authentication/presentation/widgets/submit_button.dart
@@ -6,17 +6,12 @@ import 'package:provider/provider.dart';
 class SubmitButton extends StatelessWidget {
   const SubmitButton({
     Key? key,
-    required AuthProvider authProvider,
-    required TextEditingController usernameController,
-    required TextEditingController passwordController,
-  })  : _authProvider = authProvider,
-        _usernameController = usernameController,
-        _passwordController = passwordController,
+    required this.authProvider,
+    required this.onPressed,
+  }) :
         super(key: key);
-
-  final AuthProvider _authProvider;
-  final TextEditingController _usernameController;
-  final TextEditingController _passwordController;
+final AuthProvider authProvider;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -25,12 +20,7 @@ class SubmitButton extends StatelessWidget {
       builder: (context, loading, _) {
         return ElevatedButton(
           onPressed: !loading
-              ? () {
-                  _authProvider.login(
-                    username: _usernameController.text,
-                    password: _passwordController.text,
-                  );
-                }
+              ? onPressed
               : null,
           style: ButtonStyle(
             backgroundColor: MaterialStateProperty.resolveWith(

--- a/lib/features/home/presentation/providers/home_provider.dart
+++ b/lib/features/home/presentation/providers/home_provider.dart
@@ -9,9 +9,7 @@ import 'package:loan_app/features/loan_payment/ioc/ioc.dart';
 class HomeProvider extends ChangeNotifier {
   HomeProvider() {
     _eventBus.on<LoanApplicationEvent>().listen((event) async {
-      if (event == LoanApplicationEvent.success) {
-        await getActiveLoan();
-      }
+      await getActiveLoan();
     });
 
     _eventBus.on<LoanPaymentSuccess>().listen((event) async {

--- a/lib/features/loan_detail/presentation/providers/loan_cancellation_provider.dart
+++ b/lib/features/loan_detail/presentation/providers/loan_cancellation_provider.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/foundation.dart';
+import 'package:loan_app/core/events/events.dart';
+import 'package:loan_app/core/ioc/ioc.dart';
 import 'package:loan_app/features/loan_application/ioc/ioc.dart';
 
 class LoanCancellationProvider extends ChangeNotifier {
   final _loanApplicationRepo = LoanApplicationIOC.loanApplicationRepo();
+  final _eventBus = IntegrationIOC.eventBus;
 
   bool loading = false;
-  bool cancellationStatus = false;
+  bool cancelled = false;
 
   String? errorMessage;
 
@@ -15,7 +18,7 @@ class LoanCancellationProvider extends ChangeNotifier {
   }
 
   void setCancellationStatus({required bool value}) {
-    cancellationStatus = value;
+    cancelled = value;
     notifyListeners();
   }
 
@@ -43,8 +46,9 @@ class LoanCancellationProvider extends ChangeNotifier {
     result.fold(
       (error) => setErrorMessage(value: 'Error canceling loan application'),
       (value) {
-        setLoading(value: false);
         setCancellationStatus(value: true);
+        setLoading(value: false);
+        _eventBus.fire(LoanApplicationEvent.cancel);
       },
     );
     setLoading(value: false);

--- a/lib/features/loan_detail/presentation/providers/loan_cancellation_provider.dart
+++ b/lib/features/loan_detail/presentation/providers/loan_cancellation_provider.dart
@@ -47,11 +47,9 @@ class LoanCancellationProvider extends ChangeNotifier {
       (error) => setErrorMessage(value: 'Error canceling loan application'),
       (value) {
         setCancellationStatus(value: true);
-        setLoading(value: false);
         _eventBus.fire(LoanApplicationEvent.cancel);
       },
     );
     setLoading(value: false);
-    notifyListeners();
   }
 }

--- a/lib/features/loan_detail/presentation/screens/loan_detail_screen_alt.dart
+++ b/lib/features/loan_detail/presentation/screens/loan_detail_screen_alt.dart
@@ -44,7 +44,7 @@ class _LoanDetailScreenAltState extends State<LoanDetailScreenAlt> {
               backgroundColor: Colors.red,
             ),
           );
-        } else if (!_loanCancellationProvider.loading) {
+        } else if (!_loanCancellationProvider.loading && _loanCancellationProvider.cancelled) {
           Navigator.of(context).pop();
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/lib/features/loan_detail/presentation/screens/loan_detail_screen_alt.dart
+++ b/lib/features/loan_detail/presentation/screens/loan_detail_screen_alt.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'package:loan_app/core/core.dart';
 import 'package:loan_app/features/loan_application/presentation/screens/loan_application_screen.dart';
@@ -44,8 +45,8 @@ class _LoanDetailScreenAltState extends State<LoanDetailScreenAlt> {
               backgroundColor: Colors.red,
             ),
           );
-        } else if (!_loanCancellationProvider.loading && _loanCancellationProvider.cancelled) {
-          Navigator.of(context).pop();
+        } else if (!_loanCancellationProvider.loading &&
+            _loanCancellationProvider.cancelled) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
@@ -55,9 +56,11 @@ class _LoanDetailScreenAltState extends State<LoanDetailScreenAlt> {
               backgroundColor: Colors.red,
             ),
           );
+          SchedulerBinding.instance?.addPostFrameCallback((_) {
+            Navigator.of(context).pop();
+          });
         }
       });
-    // _loan = _loanDetailProvider.loan!;
     super.initState();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.0.14+26
+version: 0.0.14+27
 
 environment:
     sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
### Added
- Homepage reload on loan cancellation
- Keyboard actions on authentication form (next and submit)
- Account locked message

### Fixed
- Credo "/" issue on ios, removed "/" from the environment variable
- Authentication attempts with one or more empty fields are taken care of by the provider
